### PR TITLE
修复 ssd.py 中导致内存溢出的问题

### DIFF
--- a/ssd.py
+++ b/ssd.py
@@ -86,7 +86,8 @@ class SSD(object):
             map(lambda x: (int(x[0] * 255), int(x[1] * 255), int(x[2] * 255)),
                 self.colors))
 
-    @tf.function
+    # @tf.function
+    # 经测试 该装饰器会引起内存溢出 注释即可 不会十分影响效率
     def get_pred(self, photo):
         preds = self.ssd_model(photo, training=False)
         return preds


### PR DESCRIPTION
取消使用@tf.function装饰器 经测试 在ssd.py的get_pred函数中 该装饰器会引起内存溢出 注释即可 不会十分影响效率 可能与 [issue#6](https://github.com/bubbliiiing/ssd-tf2/issues/6) 有关  train_eager.py中未测试 故不进行commit 可以注释进行测试